### PR TITLE
Add `opentelemetry::sdk::logs::config()` for parity with `open telemetry::sdk::trace::config()`

### DIFF
--- a/opentelemetry-sdk/src/logs/config.rs
+++ b/opentelemetry-sdk/src/logs/config.rs
@@ -2,6 +2,11 @@ use std::borrow::Cow;
 
 use crate::Resource;
 
+/// Default trace configuration
+pub fn config() -> Config {
+    Config::default()
+}
+
 /// Log emitter configuration.
 #[derive(Debug, Default)]
 pub struct Config {


### PR DESCRIPTION
## Changes

Adds a `opentelemetry::sdk::logs::config()` function, equivalent to `opentelemetry::sdk::logs::Config::default()`, as such a method exists for `open telemetry::sdk::trace`.

## Merge requirement checklist

* [x] [CONTRIBUTING](https://github.com/open-telemetry/opentelemetry-rust/blob/main/CONTRIBUTING.md) guidelines followed
* [x] Unit tests added/updated (if applicable)
* [ ] Appropriate `CHANGELOG.md` files updated for non-trivial, user-facing changes
* [ ] Changes in public API reviewed (if applicable)
